### PR TITLE
Fixed incorrect branch alias definition

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
   "minimum-stability": "dev",
   "extra": {
     "branch-alias": {
-      "dev-master": "master"
+      "dev-master": "1.x-dev"
     }
   }
 }


### PR DESCRIPTION
Packagist is not able to create a package from the repository because of incorrect [branch alias](https://getcomposer.org/doc/articles/aliases.md#branch-alias) definition.

Error occured:
`Skipped branch master, Invalid package information: 
extra.branch-alias.dev-master : the target branch (master) must end in -dev`

Fix that I propose will point all requests of the 1 version with "development" stability to the master branch.  